### PR TITLE
fix a bug. where the console chat isn't saved in the history

### DIFF
--- a/src/rconsoleProvider.ts
+++ b/src/rconsoleProvider.ts
@@ -261,6 +261,7 @@ async function activate_chat(messages: [string, string][], question: string, edi
     if (!chat) {
         return;
     }
+
     if(new_question) {
         await chat.post_question_and_communicate_answer(
             question,
@@ -269,6 +270,8 @@ async function activate_chat(messages: [string, string][], question: string, edi
             false,
             messages,
             );
+    } else {
+        await chat.chatHistoryProvider.save_messages_list(chat.chat_id, messages, "");
     }
 
 }


### PR DESCRIPTION
Issue: console chats aren't initially saved when opened in the sidebar.

to recreate: open console chat, run a command, move to side bar, press back button (or open tab)