### PR TITLE
fix: multiple commands loses history

### DIFF
--- a/src/rconsoleCommands.ts
+++ b/src/rconsoleCommands.ts
@@ -229,7 +229,8 @@ function _run_command(cmd: string, doc_uri: string, messages: Messages, update_t
     const messageWithUserInput = [
         ...messages
     ];
-    messageWithUserInput.push(["user", "```\n" + code_snippet + "\n```\n\n" + text + "\n"]);
+    const formatted_question = code_snippet ?  "```\n" + code_snippet + "\n```\n\n" + text + "\n" : `\n${text}\n`;
+    messageWithUserInput.push(["user", formatted_question]);
     let cancellationTokenSource = new vscode.CancellationTokenSource();
     let cancellationToken = cancellationTokenSource.token;
     editor.selection = new vscode.Selection(editor.selection.start, editor.selection.start);

--- a/src/rconsoleProvider.ts
+++ b/src/rconsoleProvider.ts
@@ -103,19 +103,6 @@ export async function open_refact_console_between_lines(editor: vscode.TextEdito
     let messages: [string, string][] = rconsoleCommands.initial_messages(working_on_attach_filename, working_on_attach_code);
 
     function messages_to_comments() {
-        // use this to show all of the messages from the ai
-        // let new_comments = [];
-        // for (let [author, text] of messages) {
-        //     if (author === "context_file") {
-        //         continue;
-        //     }
-        //     if (author === "user") {
-        //         continue;
-        //     }
-        //     new_comments.push(message_to_comment(author, text));
-        // }
-
-        // use this to only show the most recent message from the ai
         const assistant_messages = messages.filter(message => message[0] !== "context_file" && message[0] !== "user");
         const last_message = assistant_messages.slice(-1);
         const new_comments = last_message.map(([author, message]) => message_to_comment(author, message));

--- a/src/rconsoleProvider.ts
+++ b/src/rconsoleProvider.ts
@@ -103,16 +103,23 @@ export async function open_refact_console_between_lines(editor: vscode.TextEdito
     let messages: [string, string][] = rconsoleCommands.initial_messages(working_on_attach_filename, working_on_attach_code);
 
     function messages_to_comments() {
-        let new_comments = [];
-        for (let [author, text] of messages) {
-            if (author === "context_file") {
-                continue;
-            }
-            if (author === "user") {
-                continue;
-            }
-            new_comments.push(message_to_comment(author, text));
-        }
+        // use this to show all of the messages from the ai
+        // let new_comments = [];
+        // for (let [author, text] of messages) {
+        //     if (author === "context_file") {
+        //         continue;
+        //     }
+        //     if (author === "user") {
+        //         continue;
+        //     }
+        //     new_comments.push(message_to_comment(author, text));
+        // }
+
+        // use this to only show the most recent message from the ai
+        const assistant_messages = messages.filter(message => message[0] !== "context_file" && message[0] !== "user");
+        const last_message = assistant_messages.slice(-1);
+        const new_comments = last_message.map(([author, message]) => message_to_comment(author, message));
+
         if (new_comments.length === 0) {
             new_comments.push(message_to_comment(embelish_author("assistant"), "Thinking..."));
         }

--- a/src/rconsoleProvider.ts
+++ b/src/rconsoleProvider.ts
@@ -179,7 +179,7 @@ export async function open_refact_console_between_lines(editor: vscode.TextEdito
                             });
                         }
                         // messages = [["Command", cmd]];
-                        messages = [];
+                        // messages = [];
                         messages_to_comments();
                         activate_cmd(cmd, editor, messages, update_thread_callback, end_thread_callback);
                         return;


### PR DESCRIPTION
Fixes a bug in the chat-console, where when running multiple commands the context file is lost.
To recreate 
Highlight text, press F1, type `/explain`, then type `/improve`  