### PR TITLE
fix: update chat history in the side bar when asking a new question from a tab

### DIFF
--- a/src/chatTab.ts
+++ b/src/chatTab.ts
@@ -382,6 +382,12 @@ export class ChatTab {
             this.messages,
             model,
         );
+
+        // update side panel if this is a new question and no other chat is active
+        if("reveal" in this.web_panel && this.messages.length === 1 && global.side_panel && global.side_panel.chat === null) {
+            global.side_panel.goto_main();
+        }
+
         if (this.messages.length > 10) {
             this.messages.shift();
             this.messages.shift(); // so it always starts with a user


### PR DESCRIPTION
### Issue description
Given a new chat has been opened in a new tab, when asking questions the sidebar is not updated.

### To recreate
Open a new chat from the side panel, click `open tab`, ask the first question... (the chat history), click on another question and then back to see the new question in the history.

