### PR TITLE
fix: add padding to the top of the content when opening a chat in a tab

### DIFF
--- a/assets/chat.css
+++ b/assets/chat.css
@@ -59,6 +59,10 @@ body.vscode-dark {
     overflow-y: auto;
 }
 
+.refactcss-chat__content[data-state="tab"] {
+    padding-top: 10px;
+}
+
 .refactcss-chat__welcome {
     padding: 10px;
     margin-bottom: 10px;

--- a/src/chatTab.ts
+++ b/src/chatTab.ts
@@ -534,7 +534,7 @@ export class ChatTab {
 
                     <div class="refactcss-chat__wrapper">
                         <div class="refactcss-chat__inner">
-                            <div class="refactcss-chat__content">
+                            <div class="refactcss-chat__content" ${isTab ? "data-state=\"tab\"": ""}>
                                 <div class="refactcss-chat__welcome">
                                     Welcome to Refact chat! How can I assist you today? Please type question below.
                                 </div>


### PR DESCRIPTION
### notes
It seams vscode only supports one class name per element, so a `data-state="tab"` attribute and css-selector has been added to apply a little bit of extra padding when the user open the chat in a window-tab. 

