### PR TITLE
WIP: append updated context file to messages and run command

### DIFF
--- a/src/rconsoleCommands.ts
+++ b/src/rconsoleCommands.ts
@@ -7,7 +7,7 @@ import * as estate from "./estate";
 
 export type ThreadCallback = (role: string, answer: string) => void;
 export type Messages = [string, string][];
-export type ThreadEndCallback = (messages: Messages) => void;
+export type ThreadEndCallback = (messages: Messages, largest_block: string) => void;
 
 
 
@@ -180,7 +180,7 @@ export async function stream_chat_without_visible_chat(
                 }
             }
 
-            end_thread_callback(messages);
+            end_thread_callback(messages, largest_block);
 
             if (largest_block) {
                 let last_affected_line = chatTab.diff_paste_back(


### PR DESCRIPTION
In the rconsole, when I type /shorter, wait and then run /shorter again, the output of the prevoius command should be fead into the next one.

To check:
+ commands that don't produce new code (should it keep the diff?)
+ commands that shouldn't create a diff might create a new context file.

To Fix:
+ hints are not displayed on the second try
+ screen should scroll to rconsole when it's opened.
+ commands that shouldn't create a diff, cause the diff to be lost
+ add only selected text?
