### PR TITLE
V1.2 Chat and toolbox model bugs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,5 @@
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
     "typescript.tsc.autoDetect": "off",
+    "editor.formatOnSave": false
 }

--- a/src/chatTab.ts
+++ b/src/chatTab.ts
@@ -711,6 +711,13 @@ export async function chat_model_get(): Promise<[string, string]>
     if (!context) {
         return ["", ""];
     }
+
+    try {
+        await global.rust_binary_blob?.read_caps();
+    } catch {
+        return ["", ""];
+    }
+
     let chat_model_ = await context.globalState.get("chat_model");
     let chat_model_function_ = await context.globalState.get("chat_model_function");
     let chat_model: string = "";

--- a/src/chatTab.ts
+++ b/src/chatTab.ts
@@ -92,7 +92,7 @@ export class ChatTab {
     }
 
     dispose() {
-        const otherTabs = global.open_chat_tabs.filter(openTab => openTab.chat_id === this.chat_id);
+        const otherTabs = global.open_chat_tabs.filter(openTab => openTab.chat_id !== this.chat_id);
         global.open_chat_tabs = otherTabs;
     }
 


### PR DESCRIPTION
### To recreate:
Set up selfhosted, chat with a model, remove the model then open the toolbox to see an error.

### How it was fixed:
update global caps by calling `global.rust_binary_blob?.read_caps()` to the saved model from the chat can be validated against the most recent caps.

### Extra
Small bug when opening and close the same chat tab.