### PR TITLE
wip(menu) : add chat + hot. key to menu, and fix an issue with the sh…

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
 			},
 			{
 				"command": "refactaicmd.callChat",
-				"title": "Call Chat",
+				"title": "Chat",
 				"key": "alt+c",
 				"category": "Refact.ai"
 			},
@@ -205,6 +205,10 @@
 				{
 					"submenu": "refact-access-menu",
 					"group": "z_commands"
+				},
+				{
+					"group": "z_commands",
+					"command": "refactaicmd.callChat"
 				}
 			],
 			"refact-access-menu": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,12 +42,17 @@ declare global {
     var comment_file_uri: vscode.Uri|undefined;
 }
 
-async function pressed_call_chat() {
+async function pressed_call_chat(n = 0) {
     let editor = vscode.window.activeTextEditor;
     if(global.side_panel && !global.side_panel._view) {
+
         await vscode.commands.executeCommand(sidebar.default.viewType + ".focus");
-        // TODO: is there an event it should wait for before opening the chat?
-        await new Promise((resolve, reject) => setTimeout(resolve, 100));
+
+        const delay = (n + 1) * 10;
+        if(delay > 200) { return; }
+
+        setTimeout(() => pressed_call_chat(n + 1), delay);
+        return;
     }
 
     await open_chat_tab(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,8 +43,13 @@ declare global {
 }
 
 async function pressed_call_chat() {
-    console.log(["pressed_call_chat"]);
     let editor = vscode.window.activeTextEditor;
+    if(global.side_panel && !global.side_panel._view) {
+        await vscode.commands.executeCommand(sidebar.default.viewType + ".focus");
+        // TODO: is there an event it should wait for before opening the chat?
+        await new Promise((resolve, reject) => setTimeout(resolve, 100));
+    }
+
     await open_chat_tab(
         "",
         editor,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,6 +53,8 @@ async function pressed_call_chat(n = 0) {
 
         setTimeout(() => pressed_call_chat(n + 1), delay);
         return;
+    } else if (global.side_panel && global.side_panel._view && !global.side_panel?._view?.visible) {
+        global.side_panel._view.show();
     }
 
     await open_chat_tab(

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -56,6 +56,8 @@ export class PanelWebview implements vscode.WebviewViewProvider {
     public chat: chatTab.ChatTab | null = null;
     public chatHistoryProvider: ChatHistoryProvider|undefined;
 
+    public static readonly viewType = "refactai-toolbox";
+
     constructor(private readonly _context: any) {
         this.chatHistoryProvider = undefined;
         this.address = "";


### PR DESCRIPTION
TODO:
[x] Add `chat` to right click menu with shortcut key

Fixed:
[x] a bug where pressing the hot key or menu item wouldn't open chat unless the side bar was already open.

Other bugs found:
[x] hot key only works one time if refact isn't open in the side bar
[ ] console error: `Refused to apply inline style because it violates the following Content Security Policy directive: "style-src-attr 'sha256-tQhKwS01F0Bsw/EwspVgMAqfidY8gpn/+DKLIxQ65hg=' 'unsafe-hashes'". Either the 'unsafe-inline' keyword, a hash ('sha256-Qg1aIU8FZMYkvtyVGm/iZPJvQYu9DL7QQrCPQzg+BPo='), or a nonce ('nonce-...') is required to enable inline execution.`