### PR TITLE
Shared chat lib invalidate stats cache

### DIFF
--- a/src/statisticTab.ts
+++ b/src/statisticTab.ts
@@ -3,13 +3,10 @@
 import * as vscode from "vscode";
 import {
     EVENT_NAMES_TO_STATISTIC,
-    EVENT_NAMES_FROM_STATISTIC,
-    SetStatisticsHash,
   } from "refact-chat-js/dist/events";
 import * as fetchAPI from "./fetchAPI";
 import { v4 as uuidv4 } from "uuid";
-import {secret_api_key, get_address} from './userLogin';
-import { createHash } from "crypto";
+
 
 export class StatisticTab {
     private _disposables: vscode.Disposable[] = [];
@@ -40,31 +37,11 @@ export class StatisticTab {
                 });
               });
           }
-
-          case EVENT_NAMES_FROM_STATISTIC.READY: {
-            const message: SetStatisticsHash = {
-              type: EVENT_NAMES_TO_STATISTIC.SET_STATISTIC_HASH,
-              payload: { data: this.createStatisticsHash() }
-            };
-
-            this.web_panel.webview.postMessage(message);
-          }
-
         }
     }
 
     dispose() {
         this._disposables.forEach((d) => d.dispose());
-    }
-
-    createStatisticsHash() {
-        const sessionId = vscode.env.sessionId;
-        const user = global.user_logged_in;
-        const address = get_address();
-        const apiKey = secret_api_key();
-        const str = `${sessionId}:${user}:${address}:${apiKey}`;
-        const hash = createHash("md5").update(str).digest("hex");
-        return hash;
     }
 
     public get_html_for_statistic(

--- a/src/statisticTab.ts
+++ b/src/statisticTab.ts
@@ -8,7 +8,7 @@ import {
   } from "refact-chat-js/dist/events";
 import * as fetchAPI from "./fetchAPI";
 import { v4 as uuidv4 } from "uuid";
-import {secret_api_key} from './userLogin';
+import {secret_api_key, get_address} from './userLogin';
 import { createHash } from "crypto";
 
 export class StatisticTab {
@@ -59,8 +59,11 @@ export class StatisticTab {
 
     createStatisticsHash() {
         const sessionId = vscode.env.sessionId;
+        const user = global.user_logged_in;
+        const address = get_address();
         const apiKey = secret_api_key();
-        const hash = createHash("md5").update(apiKey + sessionId).digest("hex");
+        const str = `${sessionId}:${user}:${address}:${apiKey}`;
+        const hash = createHash("md5").update(str).digest("hex");
         return hash;
     }
 

--- a/src/statisticTab.ts
+++ b/src/statisticTab.ts
@@ -3,6 +3,8 @@
 import * as vscode from "vscode";
 import {
     EVENT_NAMES_TO_STATISTIC,
+    EVENT_NAMES_FROM_STATISTIC,
+    SetStatisticsHash,
   } from "refact-chat-js/dist/events";
 import * as fetchAPI from "./fetchAPI";
 import { v4 as uuidv4 } from "uuid";
@@ -39,6 +41,15 @@ export class StatisticTab {
               });
           }
 
+          case EVENT_NAMES_FROM_STATISTIC.READY: {
+            const message: SetStatisticsHash = {
+              type: EVENT_NAMES_TO_STATISTIC.SET_STATISTIC_HASH,
+              payload: { data: this.createStatisticsHash() }
+            };
+
+            this.web_panel.webview.postMessage(message);
+          }
+
         }
     }
 
@@ -59,8 +70,6 @@ export class StatisticTab {
         isTab = false
     ): string {
         const nonce = uuidv4();
-
-        const hash = this.createStatisticsHash();
 
         const scriptUri = webview.asWebviewUri(
             vscode.Uri.joinPath(extensionUri, "node_modules", "refact-chat-js", "dist", "chat", "index.umd.cjs")
@@ -97,7 +106,7 @@ export class StatisticTab {
                 <script nonce="${nonce}">
                 window.onload = function() {
                     const root = document.getElementById("refact-statistic")
-                    RefactChat.renderStatistic(root, {host: "vscode", tabbed: ${isTab}, statsHash: "${hash}"});
+                    RefactChat.renderStatistic(root, {host: "vscode", tabbed: ${isTab} });
                 }
                 </script>
             </body>


### PR DESCRIPTION
Works with: https://github.com/smallcloudai/refact-chat-js/pull/7

Uses a hash made from the editors session and the api key to validate the statistics data cache.
This means that changing the api-key or restarting the editor will invalidate the statistics data