### PR TITLE
ui(hotkey): remove superscript, normal font-size and slightly opaque

### DIFF
--- a/assets/sidebar.css
+++ b/assets/sidebar.css
@@ -1250,6 +1250,5 @@ body.vscode-light .refact-welcome__subpanel {
 }
 
 .sidebar__hotkey {
-	align-self: flex-start;
-	font-size: 8px;
+	opacity: 0.8;
 }

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -449,7 +449,7 @@ export class PanelWebview implements vscode.WebviewViewProvider {
                             <?xml version="1.0" ?>
                             <svg height="1657.973px" style="enable-background:new 0 0 1692 1657.973;" version="1.1" viewBox="0 0 1692 1657.973" width="1692px" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><g id="comment"><g><path d="M1216.598,1657.973c-15.035,0-29.926-4.822-41.984-14.746l-439.527-361.254H158.332    C71.515,1281.973,0,1209.012,0,1120.074V160.168C0,71.627,71.515,0.973,158.332,0.973h1374.836    c87.743,0,158.832,70.655,158.832,159.195v959.909c0,88.938-71.089,161.896-158.832,161.896H1282v309.93    c0,25.561-14.415,48.826-37.528,59.744C1235.479,1655.892,1226.173,1657.973,1216.598,1657.973z M158.332,132.973    c-13.953,0-25.332,11.52-25.332,27.195v959.906c0,15.805,11.615,29.898,25.332,29.898H758.77c15.311,0,29.89,4.95,41.715,14.674    L1150,1451.998v-236.699c0-36.49,30.096-65.326,66.586-65.326h316.582c14.123,0,26.832-14.639,26.832-29.896V160.168    c0-15.146-12.457-27.195-26.832-27.195H158.332z"/></g></g><g id="Layer_1"/></svg>
                             New&nbsp;Chat
-                            <sup class="sidebar__hotkey">${open_chat_hotkey}</sup>
+                            <span class="sidebar__hotkey">${open_chat_hotkey}</span>
                         </button>
                     </div>
                     <div class="chat-history">


### PR DESCRIPTION
<img width="371" alt="Screenshot 2024-04-08 at 14 53 39" src="https://github.com/smallcloudai/refact-vscode/assets/7499570/482b9000-244d-4002-bf1f-36ad3c63c343">

Completes
https://github.com/orgs/smallcloudai/projects/5/views/1?pane=issue&itemId=58966966