### PR TITLE
fix(toolbox): disable lsp completion when writing in toolbox

### DIFF
--- a/src/completionProvider.ts
+++ b/src/completionProvider.ts
@@ -17,6 +17,11 @@ export class MyInlineCompletionProvider implements vscode.InlineCompletionItemPr
         cancelToken: vscode.CancellationToken
     )
     {
+
+        if(document.uri.scheme === "comment") {
+            return [];
+        }
+
         let state = estate.state_of_document(document);
         if (state) {
             if (state.get_mode() !== estate.Mode.Normal && state.get_mode() !== estate.Mode.Highlight) {


### PR DESCRIPTION
Fixes an issue where completions are added to the toolbox 

## To recreate
Open toolbox type `/help` and see a completion.

## Fix:
This disables inline completions if the document is a comment