### PR TITLE
fix(diff): stop adding empty lines to diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 	"dependencies": {
 		"@types/marked": "^4.0.8",
 		"@types/vscode": "^1.69.0",
-		"diff": "^5.1.0",
+		"diff": "^7.0.0",
 		"difflib": "^0.2.4",
 		"fetch-h2": "^3.0.2",
 		"json5": "^2.2.3",

--- a/src/interactiveDiff.ts
+++ b/src/interactiveDiff.ts
@@ -304,7 +304,7 @@ export async function present_diff_to_user(editor: vscode.TextEditor, modif_doc:
     const diff = Diff.diffLines(whole_doc, modif_doc, {
         // ignoreNewlineAtEof: true,
         ignoreWhitespace: true,
-        newlineIsToken: true,
+        // newlineIsToken: true,
     });
 
     let green_bg_ranges: vscode.Range[] = [];

--- a/src/interactiveDiff.ts
+++ b/src/interactiveDiff.ts
@@ -300,7 +300,13 @@ export async function present_diff_to_user(editor: vscode.TextEditor, modif_doc:
         console.log(["apply diff -- no change"]);
         // no change, but go on because we want UI to be the same
     }
-    const diff = Diff.diffLines(whole_doc, modif_doc);
+
+    const diff = Diff.diffLines(whole_doc, modif_doc, {
+        // ignoreNewlineAtEof: true,
+        ignoreWhitespace: true,
+        newlineIsToken: true,
+    });
+
     let green_bg_ranges: vscode.Range[] = [];
     let red_bg_ranges: vscode.Range[] = [];
     let very_green_bg_ranges: vscode.Range[] = [];

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -553,7 +553,7 @@ export class PanelWebview implements vscode.WebviewViewProvider {
         );
         const indent = selectedLine.match(spaceRegex)?.[0] ?? "";
         const needsNewLine = code_block.endsWith("\n") === false;
-        const indentedCode = (indent + code_block).replace(/\n/gm, "\n" + indent) + (needsNewLine ? "\n" : "");
+        const indentedCode = (indent + code_block).replace(/\n(?!$)/gm, "\n" + indent) + (needsNewLine ? "\n" : "");
 
         const range = new vscode.Range(startOfLine, selection.end);
 


### PR DESCRIPTION
Updated diff library, and set `ignoreWhitespace` and `newlineIsToken` to true

Before:

https://github.com/user-attachments/assets/80aa8e56-26b0-4220-9d23-28d364dd3fb6

After:

https://github.com/user-attachments/assets/36ed915e-f518-4b3f-b1aa-d531d849350c

