### PR TITLE
chore(diff-api): remove diff-api calls from fetch and type imports from chat.

### DIFF
--- a/src/fetchAPI.ts
+++ b/src/fetchAPI.ts
@@ -5,18 +5,9 @@ import * as usabilityHints from "./usabilityHints";
 import * as estate from "./estate";
 import * as statusBar from "./statusBar";
 import {
-	// isCommandPreviewResponse,
-	// isDetailMessage,
 	type CapsResponse,
-	// type CommandCompletionResponse,
-	// type ChatContextFileMessage,
-	// type ChatContextFile,
-	// isCustomPromptsResponse,
     type CustomPromptsResponse,
     ChatMessages,
-    DiffChunk,
-    DiffAppliedStateResponse,
-    DiffOperationResponse,
 } from "refact-chat-js/dist/events";
 
 
@@ -681,54 +672,6 @@ export async function get_tools(notes: boolean = false): Promise<AtToolResponse>
     return tools;
 }
 
-export async function get_diff_state(chunks: DiffChunk[]): Promise<DiffAppliedStateResponse> {
-    const url = rust_url("/v1/diff-state");
-
-    if (!url) {
-        return Promise.reject("unable to get applied diffs url");
-    }
-
-    const request = new fetchH2.Request(url, {
-        method: "POST",
-        body: JSON.stringify({ chunks }),
-    });
-
-    const response = await fetchH2.fetch(request);
-
-    if (!response.ok) {
-        console.log(["applied-diffs response http status", response.status]);
-        return Promise.reject("unable to get applied diffs");
-
-    }
-
-    const json: DiffAppliedStateResponse = await response.json();
-
-    return json;
-}
-
-export async function send_chunks_to_diff_apply(chunks: DiffChunk[], to_apply: boolean[]): Promise<DiffOperationResponse> {
-    const url = rust_url("/v1/diff-apply");
-
-    if (!url) {
-        return Promise.reject("unable to get applied diffs url");
-    }
-
-    const request = new fetchH2.Request(url, {
-        method: "POST",
-        body: JSON.stringify({ chunks, apply: to_apply }),
-    });
-
-    const response = await fetchH2.fetch(request);
-
-    if (!response.ok) {
-        console.log(["applied-diffs response http status", response.status]);
-        return Promise.reject("unable to apply applied diffs");
-    }
-
-    const json: DiffOperationResponse = await response.json();
-
-    return json;
-}
 
 export async function lsp_set_active_document(editor: vscode.TextEditor)
 {


### PR DESCRIPTION
Related to https://github.com/smallcloudai/refact-chat-js/pull/142