### PR TITLE
Fix: CodeLens double-click & File Attachment

### DIFF
--- a/src/codeLens.ts
+++ b/src/codeLens.ts
@@ -98,9 +98,11 @@ const sendCodeLensToChat = (messages: {content: string; role: string;}[], relati
         return;
     }
 
+    const cursor = vscode.window.activeTextEditor?.selection.active.line ?? null;
+
     const messageBlock = messages.find((message: {content: string; role: string;}) => message.role === "user")?.content
         .replace("%CURRENT_FILE%", relative_path)
-        .replace("%CURSOR_LINE%", "")
+        .replace("%CURSOR_LINE%", cursor ? (cursor + 1).toString() : "")
         .replace("%CODE_SELECTION%", text);
     
     // TODO: send auto_submit somehow?
@@ -112,6 +114,9 @@ const sendCodeLensToChat = (messages: {content: string; role: string;}[], relati
 };
 
 export async function code_lens_execute(code_lens: string, range: any) {
+    if (!global) { return; }
+    if (global.is_chat_streaming) { return; }
+    global.is_chat_streaming = true;
     if (custom_code_lens) {
         const auto_submit = custom_code_lens[code_lens]["auto_submit"];
         const new_tab = custom_code_lens[code_lens]["new_tab"];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,7 +41,7 @@ declare global {
     var open_chat_tabs: ChatTab[];
     var comment_disposables: vscode.Disposable[];
     var comment_file_uri: vscode.Uri|undefined;
-
+    var is_chat_streaming: boolean | undefined;
     var open_chat_panels: Record<string, vscode.WebviewPanel>;
 
     var toolbox_config: launchRust.ToolboxConfig | undefined;

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -560,12 +560,10 @@ export class PanelWebview implements vscode.WebviewViewProvider {
         }
 
         if(ideChatPageChange.match(e)) {
-            console.log(`[DEBUG]: current page: ${e.payload}`);
             return this.handleCurrentChatPage(e.payload);
         }
 
         if(ideDoneStreaming.match(e)) {
-            console.log(`[DEBUG]: isStreaming: ${e.payload}`);
             return this.handleStreamingChange(e.payload);
         }
 

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -30,7 +30,8 @@ import {
     ideAnimateFileStop,
     ideWriteResultsToFile,
     type PatchResult,
-    ideChatPageChange
+    ideChatPageChange,
+    ideDoneStreaming,
 } from "refact-chat-js/dist/events";
 import { basename, join } from "path";
 import { diff_paste_back } from "./chatTab";
@@ -563,6 +564,11 @@ export class PanelWebview implements vscode.WebviewViewProvider {
             return this.handleCurrentChatPage(e.payload);
         }
 
+        if(ideDoneStreaming.match(e)) {
+            console.log(`[DEBUG]: isStreaming: ${e.payload}`);
+            return this.handleStreamingChange(e.payload);
+        }
+
         // if(ideOpenChatInNewTab.match(e)) {
         //     return this.handleOpenInTab(e.payload);
         // }
@@ -673,6 +679,10 @@ export class PanelWebview implements vscode.WebviewViewProvider {
 
     async handleCurrentChatPage(page: string) {
         this.context.globalState.update("chat_page", JSON.stringify(page));
+    }
+
+    async handleStreamingChange(state: boolean) {
+        global.is_chat_streaming = state;
     }
 
     async startFileAnimation(fileName: string) {


### PR DESCRIPTION
Fixes file attachment in CodeLens instructions & prevents CodeLens to be sent multiple times by exposing `isStreaming` from `refact-chat-js`

To test out, use `wip/codelens-timeouts` branch of `refact-chat-js`
Relies on [#155](https://github.com/smallcloudai/refact-chat-js/pull/155)