### PR TITLE
WIP(Windows): Fix code lens url

### DIFF
--- a/src/codeLens.ts
+++ b/src/codeLens.ts
@@ -60,7 +60,7 @@ export class LensProvider implements vscode.CodeLensProvider
             headers: {
                 "Content-Type": "application/json",
             },
-            body: JSON.stringify({ uri: document.uri.toString() }),
+            body: JSON.stringify({ uri: document.uri.fsPath }),
         });
 
         const response = await fetchH2.fetch(request);


### PR DESCRIPTION
vscode was sending the `document.uri.string` now it sends the fsPath

but produces this error
```
{"detail":"JSON problem: invalid value: string \"/Users/marc/Projects/refact-lsp/tests/emergency_frog_situation/frog.py\", expected relative URL without a base at line 1 column 79"}
```

It seems the lsp expects an `file://` uri