### PR TITLE
Fix: Windows paths & Rainbow

### DIFF
--- a/src/estate.ts
+++ b/src/estate.ts
@@ -133,8 +133,9 @@ export function state_of_editor(editor: vscode.TextEditor|undefined, reqfrom: st
                     return other_state;
                 }
                 if (editor === current_editor) {
-                    console.log([reqfrom, "state delete/add AKA new is current", other_state.fn]);
+                    console.log([reqfrom, "state delete/add AKA new is current", removeQuestionMarks(other_state.fn)]);
                     editor2state.delete(other_editor);
+                    other_state.fn = removeQuestionMarks(other_state.fn);
                     editor2state.set(editor, other_state);
                     state = other_state;
                     state.editor = editor;
@@ -156,6 +157,11 @@ export function state_of_editor(editor: vscode.TextEditor|undefined, reqfrom: st
     return state;
 }
 
+function removeQuestionMarks(filePath: string): string {
+    let cleanedPath = filePath.replace(/\\\?\\/g, '');
+    cleanedPath = cleanedPath.replace(/^\\+/, '');
+    return cleanedPath;
+}
 
 export function state_of_document(doc: vscode.TextDocument): StateOfEditor | undefined
 {

--- a/src/estate.ts
+++ b/src/estate.ts
@@ -133,9 +133,8 @@ export function state_of_editor(editor: vscode.TextEditor|undefined, reqfrom: st
                     return other_state;
                 }
                 if (editor === current_editor) {
-                    console.log([reqfrom, "state delete/add AKA new is current", removeQuestionMarks(other_state.fn)]);
+                    console.log([reqfrom, "state delete/add AKA new is current", other_state.fn]);
                     editor2state.delete(other_editor);
-                    other_state.fn = removeQuestionMarks(other_state.fn);
                     editor2state.set(editor, other_state);
                     state = other_state;
                     state.editor = editor;
@@ -155,12 +154,6 @@ export function state_of_editor(editor: vscode.TextEditor|undefined, reqfrom: st
     }
     state.last_used_ts = Date.now();
     return state;
-}
-
-function removeQuestionMarks(filePath: string): string {
-    let cleanedPath = filePath.replace(/\\\?\\/g, '');
-    cleanedPath = cleanedPath.replace(/^\\+/, '');
-    return cleanedPath;
 }
 
 export function state_of_document(doc: vscode.TextDocument): StateOfEditor | undefined

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -710,7 +710,8 @@ export class PanelWebview implements vscode.WebviewViewProvider {
         const uri = vscode.Uri.file(normalized_path);
 
         console.log(`[DEBUG]: (animation) opening file: `, {value: relative_path});
-
+        
+        console.log(`[COND]: openFiles.some(file => file.includes(relative_path): ${openFiles.some(file => file.includes(relative_path))}`);
         if(!openFiles.some(file => file.includes(relative_path))|| !editor) {return;}
         const document = await vscode.workspace.openTextDocument(uri);
 
@@ -741,7 +742,7 @@ export class PanelWebview implements vscode.WebviewViewProvider {
         const relative_path = path.relative(workspace_path, fileName.replace(/\?/g, ''));
 
         console.log(`[DEBUG]: opening file: `, normalized_path);
-
+        console.log(`[COND]: openFiles.some(file => file.includes(relative_path): ${openFiles.some(file => file.includes(relative_path))}`);
         if(!openFiles.some(file => file.includes(relative_path))|| !editor) {return;}
 
         const state = estate.state_of_editor(editor, "stop_animate for file: " + uri);

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -613,7 +613,7 @@ export class PanelWebview implements vscode.WebviewViewProvider {
 
     createNewFileWithContent(fileName: string, content: string) {
         const uri = this.filePathToUri(fileName);
-        const newFile = vscode.Uri.parse('untitled:' + uri);
+        const newFile = vscode.Uri.parse('untitled:' + uri.fsPath);
         vscode.workspace.openTextDocument(newFile).then(document => {
             const edit = new vscode.WorkspaceEdit();
             edit.insert(newFile, new vscode.Position(0, 0), content);

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -685,15 +685,18 @@ export class PanelWebview implements vscode.WebviewViewProvider {
     }
 
     removeQuestionMarks(filePath: string): string {
+        // Remove the sequence '\\?\\'
         let cleanedPath = filePath.replace(/\\\?\\/g, '');
+        // Remove leading backslashes if present
         cleanedPath = cleanedPath.replace(/^\\+/, '');
+        // Replace question marks and backslashes
+        // return cleanedPath.replace(/\?/g, '').replace(/\\/g, '/');
         return cleanedPath;
     }
 
     async startFileAnimation(fileName: string) {
 
         const openFiles = this.getOpenFiles();
-        console.log(`[DEBUG]: opened files: `, openFiles);
         const editor = vscode.window.activeTextEditor;
 
         const workspaceFolders = vscode.workspace.workspaceFolders;
@@ -701,15 +704,11 @@ export class PanelWebview implements vscode.WebviewViewProvider {
             return;
         }
         
-        const workspace_path = workspaceFolders[0].uri.fsPath;
-        console.log(`[DEBUG]: workspacePath: `, workspace_path);
-        
+        const workspace_path = workspaceFolders[0].uri.fsPath;        
         const relative_path = path.relative(workspace_path, fileName.replace(/\?/g, ''));
 
         const normalized_path = this.removeQuestionMarks(fileName);
         const uri = vscode.Uri.file(normalized_path);
-
-        console.log(`[DEBUG]: (animation) opening file: `, {value: relative_path});
         
         console.log(`[COND]: openFiles.some(file => file.includes(relative_path): ${openFiles.some(file => file.includes(relative_path))}`);
         if(!openFiles.some(file => file.includes(relative_path))|| !editor) {return;}
@@ -738,10 +737,8 @@ export class PanelWebview implements vscode.WebviewViewProvider {
         }
         
         const workspace_path = workspaceFolders[0].uri.fsPath;
-        console.log(`[DEBUG]: workspacePath: `, workspace_path);
         const relative_path = path.relative(workspace_path, fileName.replace(/\?/g, ''));
 
-        console.log(`[DEBUG]: opening file: `, normalized_path);
         console.log(`[COND]: openFiles.some(file => file.includes(relative_path): ${openFiles.some(file => file.includes(relative_path))}`);
         if(!openFiles.some(file => file.includes(relative_path))|| !editor) {return;}
 
@@ -840,32 +837,11 @@ export class PanelWebview implements vscode.WebviewViewProvider {
 
 
     async handleOpenFile(file: {file_name:string, line?: number}) {
-        //
-
-        // const workspaceFolders = vscode.workspace.workspaceFolders;
-        // let relative_path: string = "";
-        // let workspace_path: string = "";
-        // if (workspaceFolders) {
-        //     workspace_path = workspaceFolders[0].uri.fsPath;
-        //     console.log(`[DEBUG]: workspacePath: `, workspace_path);
-        //     relative_path = path.relative(workspace_path, file.file_name.replace(/\?/g, ''));
-        // }
-
-        function removeQuestionMarks(filePath: string): string {
-            // Remove the sequence '\\?\\'
-            let cleanedPath = filePath.replace(/\\\?\\/g, '');
-            // Remove leading backslashes if present
-            cleanedPath = cleanedPath.replace(/^\\+/, '');
-            // Replace question marks and backslashes
-            return cleanedPath.replace(/\?/g, '').replace(/\\/g, '/');
-        }
-
-        const normalized_path = removeQuestionMarks(file.file_name);
-
-        console.log(`[DEBUG]: opening file: `, normalized_path);
+        const normalized_path = this.removeQuestionMarks(file.file_name);
 
         const uri = vscode.Uri.file(normalized_path);
         const document = await vscode.workspace.openTextDocument(uri);
+
         if(file.line !== undefined) {
             const position = new vscode.Position(file.line ?? 0, 0);
             const editor = await vscode.window.showTextDocument(document);


### PR DESCRIPTION
Treats well of paths for direct file opening & rainbow animation is getting restored on Windows

Relies on this pull request from `refact-chat-js`:
https://github.com/smallcloudai/refact-chat-js/pull/160