### PR TITLE
Fix: Unfreezing CodeLens if auto_submit is set to false

### DIFF
--- a/src/codeLens.ts
+++ b/src/codeLens.ts
@@ -157,9 +157,15 @@ export async function code_lens_execute(code_lens: string, range: any) {
                 vscode.commands.executeCommand('refactaicmd.callChat', '');
             }
             sendCodeLensToChat(messages, relative_path, text, auto_submit);
+            if (!auto_submit) {
+                global.is_chat_streaming = false;
+            }
         } else {
             vscode.commands.executeCommand('refactaicmd.callChat', '');
             sendCodeLensToChat(messages, relative_path, text, auto_submit);
+            if (!auto_submit) {
+                global.is_chat_streaming = false;
+            }
         }
     }
 }


### PR DESCRIPTION
Previously, if codelens instructions were containing flag `auto_submit` set to `false` - all other intents to click on codelens were prevented.

This pull request provides a fix of that unexpected behavior.

How to test?

- Step 1: Set codelens instructions to `auto_submit: false`, `new_tab: false`
- Step 2: Try to click Explain first
- Step 3: Try to click Find Problems then

Expected Result:
Text within textarea should be replaced by text of the instruction itself, codelens should not be frozen anymore.