### PR TITLE
Fix: Quick Actions commands execution

### DIFF
--- a/src/quickProvider.ts
+++ b/src/quickProvider.ts
@@ -96,7 +96,6 @@ export class QuickActionProvider implements vscode.CodeActionProvider {
         if (!global || !global.side_panel || !global.side_panel._view) {
             return;
         }
-        // TODO: send auto_submit somehow?
         const message = setInputValue({
             value: messageBlock,
             // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -126,6 +125,7 @@ export class QuickActionProvider implements vscode.CodeActionProvider {
         let middleLineOfSelection = 0;
         let diagnosticMessage = '';
 
+        // if no diagnostic were present, taking user's selection instead
         if (actionId === 'bugs' && context?.diagnostics && context.diagnostics.length > 0) {
             const diagnostic = context.diagnostics[0];
             diagnosticMessage = diagnostic.message;


### PR DESCRIPTION
# Fix: Quick Actions commands execution

<!-- Provide a clear and concise title for your pull request. Example: "Fix: Responsive issues on the homepage" -->

## Description

<!-- Describe the changes made in this pull request in detail. Explain the purpose of the changes and how they solve the problem or implement the feature. -->

- Problem: Quick Actions are creating entirely new chat thread manually. Because of that, we are loosing selected by user model, agent capabilities, even tools. Also, if user clicks on "Find bugs", user's selection gets ignored, because it was relying only on range of code found as potential compilation errors (`vscode.Diagnostic[]`)
- Solution: Using the same approach, as CodeLens instructions use, sending to the client formatted message and then submitting the form with snippets, files and actual message attached. For bugs, checking if diagnostics are present, if yes, then relying on them, if not, taking user's lines selection to be working with later on.
- [💡 switches model back to 4o-mini, use the same method as codelens](https://refact.fibery.io/Software_Development/UI-VS-347#Task/switches-model-back-to-4o-mini,-use-the-same-method-as-codelens-323)

## Type of change

<!-- Select the appropriate type of change. Add an `x` in the box that applies. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (no functional changes, only code improvements)
- [ ] Documentation update

## How to Test

<!-- Provide instructions for testing the changes. Include any relevant details such as test setup, steps to reproduce the issue, and expected outcomes. -->

- Step 1: Click on any lightbulb instruction, with line selection or without
- Step 2: Chat should get opened in a new tab with visible message and code snippet attached.

## Checklist

<!-- Ensure that your pull request follows these guidelines. Add an `x` in the box if the item is complete. -->

- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have updated the documentation where necessary.